### PR TITLE
Dyadya jora.bugfixes all

### DIFF
--- a/static/src/app/controllers/myProfileCtrl.js
+++ b/static/src/app/controllers/myProfileCtrl.js
@@ -10,10 +10,13 @@ pepo.controller('myProfileCtrl', function($location, $auth, $scope, userApi, use
   }
 
   currentUserId = $location.path().slice(2);
-  usersApi.getUser({username: currentUserId}).$promise.then(function(data) {
-    $scope.currentPageUser = data;
+  function getUser(){
+    usersApi.getUser({username: currentUserId}).$promise.then(function(data) {
+      $scope.currentPageUser = data;
     checkFollow();
   });
+  };
+  getUser();
 
   usersApi.getUserStatuses({username: currentUserId}).$promise.then(function(data){
    	$scope.tweets = data.statuses;
@@ -59,6 +62,7 @@ $scope.isSubscribe = function(userId) {
       $scope.subscribed[userId] = true;
 
       getInfoItems();
+      getUser();
     });
   }
 
@@ -68,6 +72,7 @@ $scope.isSubscribe = function(userId) {
       $scope.subscribed[userId] = false;
 
       getInfoItems();
+      getUser();
     });
   }
 

--- a/static/src/app/controllers/myProfileCtrl.js
+++ b/static/src/app/controllers/myProfileCtrl.js
@@ -60,18 +60,18 @@ $scope.isSubscribe = function(userId) {
     usersApi.followUser({username: username}).$promise.then(function(){
       //$scope.followed = true;
       $scope.subscribed[userId] = true;
-    });
     getInfoItems();
     getUser();
+    });
   }
 
   $scope.unsubscribe = function(username, userId) {
     usersApi.unfollowUser({username: username}).$promise.then(function(){
       //$scope.followed = false;
       $scope.subscribed[userId] = false;
-    });
     getInfoItems();
     getUser();
+    });
   }
 
   $scope.logout = function() {

--- a/static/src/app/controllers/myProfileCtrl.js
+++ b/static/src/app/controllers/myProfileCtrl.js
@@ -60,20 +60,18 @@ $scope.isSubscribe = function(userId) {
     usersApi.followUser({username: username}).$promise.then(function(){
       //$scope.followed = true;
       $scope.subscribed[userId] = true;
-
-      getInfoItems();
-      getUser();
     });
+    getInfoItems();
+    getUser();
   }
 
   $scope.unsubscribe = function(username, userId) {
     usersApi.unfollowUser({username: username}).$promise.then(function(){
       //$scope.followed = false;
       $scope.subscribed[userId] = false;
-
-      getInfoItems();
-      getUser();
     });
+    getInfoItems();
+    getUser();
   }
 
   $scope.logout = function() {

--- a/static/src/app/directives/header.js
+++ b/static/src/app/directives/header.js
@@ -77,7 +77,9 @@ pepo.directive('pepoHeader', function($rootScope, $auth, $location, pepsApi, use
 			    pepsApi.sendPep(newPep).$promise.then(function(data){
 			      	newPep._id = data._id;
 					newPep.createdAt = data.createdAt;
-			     	$scope.tweets.unshift(newPep);
+					if($location.url().slice(2) ==  $scope.currentUser.username || $location.url()=="/feed"){
+			     		$scope.tweets.unshift(newPep);
+			     	}
 			     	$document.scrollTop(0, 300);
 			    })
 			    .catch(function(err) {

--- a/static/src/app/directives/modalAnswer.js
+++ b/static/src/app/directives/modalAnswer.js
@@ -54,7 +54,7 @@ angular.module('pepo').directive('modalAnswer', function($rootScope, $auth, $loc
       pepsApi.sendPep(newPep).$promise.then(function(data){
         newPep._id = data._id;
         newPep.createdAt = data.createdAt;
-        if($scope.tweets!=undefined){
+        if($scope.tweets!=undefined && ($location.url().slice(2) ==  $scope.currentUser.username || $location.url()=="/feed")){
           $scope.tweets.unshift(newPep);
         }
         if($scope.currentTweet!=undefined && newPep.parent==$scope.currentTweet._id){

--- a/static/src/app/templates/my-profile.html
+++ b/static/src/app/templates/my-profile.html
@@ -19,16 +19,16 @@
     <div class="user-profile-info">
         <ul>
             <li class="user-profile-info_item user-profile-info_item__active" ng-click="itemInfo(0)" ng-class="{'user-info-item_disable': currentPageUser.statusesCount==0}">
-                <div class="user-profile-info_number">0{{currentPageUser.statusesCount}}</div>
+                <div class="user-profile-info_number">{{currentPageUser.statusesCount}}</div>
                 <div class="user-profile-info_label">пепов</div>
                 <div class="user-info-item_line" ng-class="{'first-item': varInfoArr[0], 'second-item': varInfoArr[1], 'third-item': varInfoArr[2]}"></div>
             </li>
-            <li class="user-profile-info_item" ng-click="itemInfo(1)" ng-class="{'user-info-item_disable': following.length==0}">
-                <div class="user-profile-info_number">{{following.length}}</div>
+            <li class="user-profile-info_item" ng-click="itemInfo(1)" ng-class="{'user-info-item_disable': currentPageUser.followingCount==0}">
+                <div class="user-profile-info_number">{{currentPageUser.followingCount}}</div>
                 <div class="user-profile-info_label">читаемых</div>
             </li>
-            <li class="user-profile-info_item" ng-click="itemInfo(2)" ng-class="{'user-info-item_disable': followers.length==0}">
-                <div class="user-profile-info_number">{{followers.length}}</div>
+            <li class="user-profile-info_item" ng-click="itemInfo(2)" ng-class="{'user-info-item_disable': currentPageUser.followersCount==0}">
+                <div class="user-profile-info_number">{{currentPageUser.followersCount}}</div>
                 <div class="user-profile-info_label">читателей</div>
             </li>
         </ul>

--- a/static/src/app/templates/my-profile.html
+++ b/static/src/app/templates/my-profile.html
@@ -143,7 +143,7 @@
       </div>
     </li>
   </ul>
-  <div class="load-more-btn" ng-click="loadMoreFollowers()" ng-class="{'load-more-btn__progress': followersLoading}"></div>
+  <div class="load-more-btn" ng-click="loadMoreFollowing()" ng-class="{'load-more-btn__progress': followingLoading}"></div>
 </div>
 
 <!-- Блок читателей -->
@@ -176,7 +176,7 @@
       </div>
     </li>
   </ul>
-  <div class="load-more-btn" ng-click="loadMoreFollowing()" ng-class="{'load-more-btn__progress': followingLoading}"></div>
+  <div class="load-more-btn" ng-click="loadMoreFollowers()" ng-class="{'load-more-btn__progress': followersLoading}"></div>
 </div>
 
 </section>

--- a/static/src/app/templates/my-profile.html
+++ b/static/src/app/templates/my-profile.html
@@ -126,7 +126,7 @@
         <div ng-show="subscribed[user._id]" class="pepo_btn user_unsubscribe" ng-click="unsubscribe(user.username, user._id)">Читаю</div>
         <p class="user_description">{{user.description}}</p>
 
-        <ul class="user-info">
+        <ul class="user-info" ng-class="{'mg80' : user.username == currentUser.username}">
           <li class="user-info_item">
             <div class="user-info_number">{{user.statusesCount}}</div>
             <div class="user-info_label">пепов</div>
@@ -159,7 +159,7 @@
         <div ng-show="subscribed[user._id]" class="pepo_btn user_unsubscribe" ng-click="unsubscribe(user.username, user._id)">Читаю</div>
         <p class="user_description">{{user.description}}</p>
 
-        <ul class="user-info">
+        <ul class="user-info" ng-class="{'mg80' : user.username == currentUser.username}">
           <li class="user-info_item">
             <div class="user-info_number">{{user.statusesCount}}</div>
             <div class="user-info_label">пепов</div>


### PR DESCRIPTION
Багфиксы: 3, 4, 11, 12(0.5), 18, 20
* убрал "0" нолик перед количеством пепов
* подставляю количество читателей\читаемых из followerCount, followingCount
* поправил верстку с блоком количества пепов\читатлей\читаемыхна странице профиля при отображении в подписках своего профиля этот блок теперь не западает под картинку
* поменял местами функции для отображения большего количества читателей\читаемых (было неправильно)
* при добавлении нового пепа или ответе на пеп он больше не добавляется в ленту к чужим пользователям, когда отправляешь пеп со страницы профиля чужого пользователя
